### PR TITLE
Python 3 and formatting spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-practNLPTools
-=============
+# practNLPTools
 
-Practical Natural Language Processing Tools for Humans.<br>
+Practical Natural Language Processing Tools for Humans.
+
 practNLPTools is a pythonic library over SENNA and Stanford Dependency Extractor.
 
-Functionality
-=============
+## Functionality
+
 1. Semantic Role Labeling
 2. Syntactic Parsing
 3. Part of Speech Tagging (POS Tagging)
@@ -13,38 +13,32 @@ Functionality
 5. Dependency Parsing
 6. Shallow Chunking
 
-Features
-=============
-1. Fast: SENNA is written is C. So it is Fast.
-2. We use only dependency Extractor Component of Stanford Parser, which takes in Syntactic Parse from SENNA and applies dependency Extraction. So there is no need to load parsing models for Stanford Parser, which takes time.
+## Features
+
+1. Fast: SENNA is written is C.
+2. We use only dependency Extractor Component of Stanford Parser, which takes in Syntactic Parse from SENNA and applies Dependency Extraction. So there is no need to load parsing models for Stanford Parser, which takes time.
 3. Easy to use.
-4. Platform Supported - Windows, Linux and Mac
+4. Platforms Supported - Windows, Linux and Mac
 
-Installation
-=============
+## Installation
 
-Requires:
-A computer with 500mb memory, Java Runtime Environment (1.7 preferably, works with 1.6 too, but didnt test.) installed and python.
+Requires a computer with 500mb memory, Java Runtime Environment (1.7 preferably, not thoroughly tested with 1.6 but should work) installed and python.
 
-If you are in linux:
-run:
+If you use linux:
 
     sudo python setup.py install 
 
-If you are in windows:
-run this commands as administrator:
+If you use windows (run as administrator):
 
     python setup.py install
   
+## Examples
 
-Examples
-=============
-
-Chunk and NER use BIOS Tagging Scheme. Which expands to:
+Chunk and NER use BIOS Tagging Scheme, which expands to:
 
 1. S = Tag covers Single Word.
 2. B = Tag Begins with the Word.
-3. I = Word is internal to tag which has begun.
+3. I = Word is Internal to tag which has begun.
 4. E = Tag Ends with the Word.
 5. 0 = Other tags.
 
@@ -56,7 +50,7 @@ Example:
   [Biplab]NP [is]VP [a good boy]NP [.]O
   
 
-Annotator is the only class you need. Create an annotator object.
+Annotator is the only class you need. To create an annotator object.
 
     >>>from practnlptools.tools import Annotator
     >>>annotator=Annotator()
@@ -68,12 +62,12 @@ Using Function getAnnoations(sentence) returns a dictionary of annotations.
     {'dep_parse': '', 'chunk': [('There', 'S-NP'), ('are', 'S-VP'), ('people', 'S-NP'), ('dying', 'B-VP'), ('make', 'E-VP'), ('this', 'B-NP'), ('world', 'E-NP'), ('a', 'B-NP'), ('better', 'I-NP'), ('place', 'E-NP'), ('for', 'S-PP'), ('you', 'S-NP'), ('and', 'O'), ('for', 'S-PP'), ('me.', 'S-NP')], 'pos': [('There', 'EX'), ('are', 'VBP'), ('people', 'NNS'), ('dying', 'VBG'), ('make', 'VB'), ('this', 'DT'), ('world', 'NN'), ('a', 'DT'), ('better', 'JJR'), ('place', 'NN'), ('for', 'IN'), ('you', 'PRP'), ('and', 'CC'), ('for', 'IN'), ('me.', '.')], 'srl': [{'A1': 'people', 'V': 'dying'}, {'A1': 'people  this world', 'A2': 'a better place for you and for me.', 'V': 'make'}], 'syntax_tree': '(S1(S(NP(EX There))(VP(VBP are)(NP(NP(NNS people))(SBAR(S(VBG dying)(VP(VB make)(S(NP(DT this)(NN world))(NP(DT a)(JJR better)(NN place)))(PP(PP(IN for)(NP(PRP you)))(CC and)(PP(IN for)(NP(. me.)))))))))))', 'verbs': ['dying', 'make'], 'words': ['There', 'are', 'people', 'dying', 'make', 'this', 'world', 'a', 'better', 'place', 'for', 'you', 'and', 'for', 'me.'], 'ner': [('There', 'O'), ('are', 'O'), ('people', 'O'), ('dying', 'O'), ('make', 'O'), ('this', 'O'), ('world', 'O'), ('a', 'O'), ('better', 'O'), ('place', 'O'), ('for', 'O'), ('you', 'O'), ('and', 'O'), ('for', 'O'), ('me.', 'O')]}
 
 
-Using Function getAnnoations(sentence,dep_parse=True) returns a dictionary of annotations with dependency parse, by default it is switched off.
+Using Function getAnnotations(sentence,dep_parse=True) returns a dictionary of annotations with dependency parse, by default it is switched off.
 
     >>>annotator.getAnnotations("There are people dying make this world a better place for you and for me.",dep_parse=True)
     {'dep_parse': 'expl(are-2, There-1)\nroot(ROOT-0, are-2)\nnsubj(are-2, people-3)\ndep(make-5, dying-4)\nrcmod(people-3, make-5)\ndet(world-7, this-6)\nnsubj(place-10, world-7)\ndet(place-10, a-8)\namod(place-10, better-9)\nxcomp(make-5, place-10)\nprep_for(make-5, you-12)\nconj_and(you-12, me.-15)', 'chunk': [('There', 'S-NP'), ('are', 'S-VP'), ('people', 'S-NP'), ('dying', 'B-VP'), ('make', 'E-VP'), ('this', 'B-NP'), ('world', 'E-NP'), ('a', 'B-NP'), ('better', 'I-NP'), ('place', 'E-NP'), ('for', 'S-PP'), ('you', 'S-NP'), ('and', 'O'), ('for', 'S-PP'), ('me.', 'S-NP')], 'pos': [('There', 'EX'), ('are', 'VBP'), ('people', 'NNS'), ('dying', 'VBG'), ('make', 'VB'), ('this', 'DT'), ('world', 'NN'), ('a', 'DT'), ('better', 'JJR'), ('place', 'NN'), ('for', 'IN'), ('you', 'PRP'), ('and', 'CC'), ('for', 'IN'), ('me.', '.')], 'srl': [{'A1': 'people', 'V': 'dying'}, {'A1': 'people  this world', 'A2': 'a better place for you and for me.', 'V': 'make'}], 'syntax_tree': '(S1(S(NP(EX There))(VP(VBP are)(NP(NP(NNS people))(SBAR(S(VBG dying)(VP(VB make)(S(NP(DT this)(NN world))(NP(DT a)(JJR better)(NN place)))(PP(PP(IN for)(NP(PRP you)))(CC and)(PP(IN for)(NP(. me.)))))))))))', 'verbs': ['dying', 'make'], 'words': ['There', 'are', 'people', 'dying', 'make', 'this', 'world', 'a', 'better', 'place', 'for', 'you', 'and', 'for', 'me.'], 'ner': [('There', 'O'), ('are', 'O'), ('people', 'O'), ('dying', 'O'), ('make', 'O'), ('this', 'O'), ('world', 'O'), ('a', 'O'), ('better', 'O'), ('place', 'O'), ('for', 'O'), ('you', 'O'), ('and', 'O'), ('for', 'O'), ('me.', 'O')]}
 
-You can access individual componets as:
+You can access individual components as:
 
     >>>annotator.getAnnotations("Biplab is a good boy.")['pos']
     [('Biplab', 'NNP'), ('is', 'VBZ'), ('a', 'DT'), ('good', 'JJ'), ('boy', 'NN'), ('.', '.')]
@@ -88,17 +82,17 @@ To list the verbs for which semantic roles are found.
     >>>annotator.getAnnotations("He created the robot and broke it after making it.")['verbs']
     ['created', 'broke', 'making']
 
-'srl' Returns a list of dictionaries, identifyinging sematic roles for various verbs in sentence.
+'srl' returns a list of dictionaries, identifying sematic roles for various verbs in sentence.
 
     >>>annotator.getAnnotations("He created the robot and broke it after making it.")['srl']
     [{'A1': 'the robot', 'A0': 'He', 'V': 'created'}, {'A1': 'it', 'A0': 'He', 'AM-TMP': 'after making it.', 'V': 'broke'}, {'A1': 'it.', 'A0': 'He', 'V': 'making'}]
 
-'syntax_tree' Returns syntax tree in penn Tree Bank Format.
+'syntax_tree' returns syntax tree in Penn Tree Bank Format.
 
     >>>annotator.getAnnotations("He created the robot and broke it after making it.")['syntax_tree']
     '(S1(S(NP(PRP He))(VP(VP(VBD created)(NP(DT the)(NN robot)))(CC and)(VP(VBD broke)(NP(PRP it))(PP(IN after)(S(VP(VBG making)(NP(PRP it.)))))))))'
 
-'dep_parse' Returns dependency Relations as a string. Each relation is in new line. You may require some post processing on this.
+'dep_parse' returns dependency relations as a string. Each relation is in new line. You may require some post processing on this.
 
     >>>print annotator.getAnnotations("He created the robot and broke it after making it.",dep_parse=True)['dep_parse']
     nsubj(created-2, He-1)
@@ -111,7 +105,7 @@ To list the verbs for which semantic roles are found.
     dobj(making-9, it.-10)
 
 
-If there are many sentences to annotate, Use batch Mode, annotator.getBatchAnnotations(sentences,dep_parse=True/False). Returns a list of annotation dictionaries.
+If there are many sentences to annotate, use Batch Mode: `annotator.getBatchAnnotations(sentences,dep_parse=True/False)`. Returns a list of annotation dictionaries.
 
     >>>annotator.getBatchAnnotations(["He created the robot and broke it after making it.","Biplab is a good boy."],dep_parse=True)
     [{'dep_parse': 'nsubj(created-2, He-1)\nroot(ROOT-0, created-2)\ndet(robot-4, the-3)\ndobj(created-2, robot-4)\nconj_and(created-2, broke-6)\ndobj(broke-6, it-7)\nprepc_after(broke-6, making-9)\ndobj(making-9, it.-10)', 'chunk': [('He', 'S-NP'), ('created', 'S-VP'), ('the', 'B-NP'), ('robot', 'E-NP'), ('and', 'O'), ('broke', 'S-VP'), ('it', 'S-NP'), ('after', 'S-PP'), ('making', 'S-VP'), ('it.', 'S-NP')], 'pos': [('He', 'PRP'), ('created', 'VBD'), ('the', 'DT'), ('robot', 'NN'), ('and', 'CC'), ('broke', 'VBD'), ('it', 'PRP'), ('after', 'IN'), ('making', 'VBG'), ('it.', 'PRP')], 'srl': [{'A1': 'the robot', 'A0': 'He', 'V': 'created'}, {'A1': 'it', 'A0': 'He', 'AM-TMP': 'after making it.', 'V': 'broke'}, {'A1': 'it.', 'A0': 'He', 'V': 'making'}], 'syntax_tree': '(S1(S(NP(PRP He))(VP(VP(VBD created)(NP(DT the)(NN robot)))(CC and)(VP(VBD broke)(NP(PRP it))(PP(IN after)(S(VP(VBG making)(NP(PRP it.)))))))))', 'verbs': ['created', 'broke', 'making'], 'words': ['He', 'created', 'the', 'robot', 'and', 'broke', 'it', 'after', 'making', 'it.'], 'ner': [('He', 'O'), ('created', 'O'), ('the', 'O'), ('robot', 'O'), ('and', 'O'), ('broke', 'O'), ('it', 'O'), ('after', 'O'), ('making', 'O'), ('it.', 'O')]}, {'dep_parse': 'nsubj(boy-5, Biplab-1)\ncop(boy-5, is-2)\ndet(boy-5, a-3)\namod(boy-5, good-4)\nroot(ROOT-0, boy-5)', 'chunk': [('Biplab', 'S-NP'), ('is', 'S-VP'), ('a', 'B-NP'), ('good', 'I-NP'), ('boy', 'E-NP'), ('.', 'O')], 'pos': [('Biplab', 'NNP'), ('is', 'VBZ'), ('a', 'DT'), ('good', 'JJ'), ('boy', 'NN'), ('.', '.')], 'srl': [], 'syntax_tree': '(S1(S(NP(NNP Biplab))(VP(VBZ is)(NP(DT a)(JJ good)(NN boy)))(. .)))', 'verbs': [], 'words': ['Biplab', 'is', 'a', 'good', 'boy', '.'], 'ner': [('Biplab', 'S-PER'), ('is', 'O'), ('a', 'O'), ('good', 'O'), ('boy', 'O'), ('.', 'O')]}]
@@ -121,19 +115,16 @@ Note: For illustration purposes we have used:
 
     >>>annotator.getAnnotations("He created the robot and broke it after making it.",dep_parse=True)['dep_parse']
 
-Better method is:
+A better method would be:
 
     >>>annotation=annotator.getAnnotations("He created the robot and broke it after making it.",dep_parse=True)
     >>>ner=annotation['ner']
     >>>srl=annotation['srl']
 
-Issues
-=============
+## Issues
 
-1. You cannot give sentence with '(' ')', that is left bracket aor right bracket. It will end up in returning no result. So please clean Sentences before sending to annotator.
-2. Other issue might be senna executable built for various platforms. I have not experienced it, but its highly probable. If you get this issuse:
-
-Go to folder practnlptools
+1. You cannot give sentence with '(' ')', that is left bracket or right bracket. It will end up returning no result. So your must clean sentences before sending to annotator.
+2. Other issues might involve Senna running in different platforms. If you have issues related to your platform, you may try the following.
 
     cd practnlptools
     gcc -O3 -o senna-linux64 *.c  (For linux 64 bit)
@@ -142,24 +133,23 @@ Go to folder practnlptools
     *windows: I never compiled C files in Windows.*
     python setup.py install
 
-3. Any other, you can la la laa la laaaa to  biplab12  (A T) cse d0t iitb d0t ac d0t in 
+3. Any other, you can la la laa la laaaa to biplab12  (A T) cse d0t iitb d0t ac d0t in 
 4. Issues with "pip install practnlptools"
    
 You might receive following Error while running:
-<pre>  
- Traceback (most recent call last):
- File "test.py", line 3, in <module>
-    print a.getAnnotations("This is a test.")
-  File "/usr/local/lib/python2.7/dist-packages/practnlptools/tools.py", line 206, in getAnnotations
-    senna_tags=self.getSennaTag(sentence)
-  File "/usr/local/lib/python2.7/dist-packages/practnlptools/tools.py", line 88, in getSennaTag
-    p = subprocess.Popen(senna_executable,stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
-    errread, errwrite)
-  File "/usr/lib/python2.7/subprocess.py", line 1249, in _execute_child
-    raise child_exception
-OSError: [Errno 13] Permission denied
-</pre>
+    Traceback (most recent call last):
+    File "test.py", line 3, in <module>
+        print a.getAnnotations("This is a test.")
+    File "/usr/local/lib/python2.7/dist-packages/practnlptools/tools.py", line 206, in getAnnotations
+        senna_tags=self.getSennaTag(sentence)
+    File "/usr/local/lib/python2.7/dist-packages/practnlptools/tools.py", line 88, in getSennaTag
+        p = subprocess.Popen(senna_executable,stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
+        errread, errwrite)
+    File "/usr/lib/python2.7/subprocess.py", line 1249, in _execute_child
+        raise child_exception
+    OSError: [Errno 13] Permission denied
+
 To Fix this,you can do:
-  chmod -R +x /usr/local/lib/python2.7/dist-packages/practnlptools/
-   
+
+  chmod -R +x /usr/local/lib/python2.7/dist-packages/practnlptools/   

--- a/practnlptools/tools.py
+++ b/practnlptools/tools.py
@@ -16,11 +16,12 @@ import subprocess
 import os
 from platform import architecture, system
 class Annotator:
-	r"""
+    r"""
     A general interface of the SENNA/Stanford Dependency Extractor pipeline that supports any of the
     operations specified in SUPPORTED_OPERATIONS.
-	
-    SUPPORTED_OPERATIONS: It provides Part of Speech Tags, Semantic Role Labels, Shallow Parsing (Chunking), Named Entity 	   	Recognisation (NER), Dependency Parse and Syntactic Constituency Parse. 
+    -
+    SUPPORTED_OPERATIONS: It provides Part of Speech Tags, Semantic Role Labels, Shallow Parsing (Chunking), Named Entity
+    Recognisation (NER), Dependency Parse and Syntactic Constituency Parse. 
 
     Applying multiple operations at once has the speed advantage. For example,
     senna v3.0 will calculate the POS tags in case you are extracting the named
@@ -35,261 +36,261 @@ class Annotator:
 
     Example:
 
-        
-    """
-	def getSennaTagBatch(self,sentences):
-		input_data=""
-		for sentence in sentences:
-			input_data+=sentence+"\n"
-		input_data=input_data[:-1]
-		package_directory = os.path.dirname(os.path.abspath(__file__))
-		os_name = system()
-		executable=""
-		if os_name == 'Linux':
-		    bits = architecture()[0]
-		    if bits == '64bit':
-		    	executable='senna-linux64'
-		    elif bits == '32bit':
-			executable='senna-linux32'
-		    else:
-			executable='senna'
-		if os_name == 'Windows':
-		    executable='senna-win32.exe'
-		if os_name == 'Darwin':
-		    executable='senna-osx'
-		senna_executable = os.path.join(package_directory,executable)
-		cwd=os.getcwd()
-		os.chdir(package_directory)
-		p = subprocess.Popen(senna_executable,stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-		senna_stdout = p.communicate(input=input_data)[0]
-		os.chdir(cwd)
-		return senna_stdout.split("\n\n")[0:-1]
 
-	def getSennaTag(self,sentence):
-		input_data=sentence
-		package_directory = os.path.dirname(os.path.abspath(__file__))
-		os_name = system()
-		executable=""
-		if os_name == 'Linux':
-		    bits = architecture()[0]
-		    if bits == '64bit':
-		    	executable='senna-linux64'
-		    elif bits == '32bit':
-			executable='senna-linux32'
-		    else:
-			executable='senna'
-		if os_name == 'Windows':
-		    executable='senna-win32.exe'
-		if os_name == 'Darwin':
-		    executable='senna-osx'
-		senna_executable = os.path.join(package_directory,executable)
-		cwd=os.getcwd()
-		os.chdir(package_directory)
-		p = subprocess.Popen(senna_executable,stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-		senna_stdout = p.communicate(input=input_data)[0]
-		os.chdir(cwd)
-		return senna_stdout
-	def getDependency(self,parse):
-		package_directory = os.path.dirname(os.path.abspath(__file__))
-		cwd=os.getcwd()
-		os.chdir(package_directory)
-		parsefile=open(cwd+"/in.parse","w")
-		parsefile.write(parse)
-		parsefile.close()
-		p=subprocess.Popen(['java','-cp','stanford-parser.jar', 'edu.stanford.nlp.trees.EnglishGrammaticalStructure', '-treeFile', cwd+'/in.parse','-collapsed'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-		p.wait()	
-		stanford_out=p.stdout.read()
-		os.chdir(cwd)
-		return stanford_out.strip()
-	def getBatchAnnotations(self,sentences,dep_parse=False):
-		annotations=[]	
-		batch_senna_tags=self.getSennaTagBatch(sentences)
-		for senna_tags in batch_senna_tags:
-			annotations+=[self.getAnnotationsAfterTagging(senna_tags)]
-		if(dep_parse):
-			syntax_tree=""
-			for annotation in annotations:
-				syntax_tree+=annotation['syntax_tree']
-			dependencies=self.getDependency(syntax_tree).split("\n\n")
-			#print dependencies
-			if (len(annotations)==len(dependencies)):
-				for (d,a) in zip(dependencies,annotations):
-					a["dep_parse"]=d
-		return annotations
-		
-	def getAnnotationsAfterTagging(self,senna_tags,dep_parse=False):
-		annotations={}
-		senna_tags=map(lambda x: x.strip(),senna_tags.split("\n"))
-		no_verbs=len(senna_tags[0].split("\t"))-6
-		words=[]
-		pos=[]
-		chunk=[]
-		ner=[]
-		verb=[]
-		srls=[]
-		syn=[]
-		for senna_tag in senna_tags:
-			senna_tag=senna_tag.split("\t")
-			words+=[senna_tag[0].strip()]
-			pos+=[senna_tag[1].strip()]
-			chunk+=[senna_tag[2].strip()]
-			ner+=[senna_tag[3].strip()]
-			verb+=[senna_tag[4].strip()]
-			srl=[]
-			for i in range(5,5+no_verbs):
-				srl+=[senna_tag[i].strip()]
-			srls+=[tuple(srl)]
-			syn+=[senna_tag[-1]]
-		roles=[]
-		for j in range(no_verbs):
-			role={}
-			i=0
-			temp=""
-			curr_labels=map(lambda x: x[j],srls)
-			for curr_label in curr_labels:
-				splits=curr_label.split("-")
-				if(splits[0]=="S"):
-					if(len(splits)==2):
-				        	if(splits[1]=="V"):
-				                	role[splits[1]]=words[i]
-				                else:
-				                	if splits[1] in role:
-				                        	role[splits[1]]+=" "+words[i]
-				               		else:
-				                        	role[splits[1]]=words[i]
-				      	elif(len(splits)==3):
-				        	if splits[1]+"-"+splits[2] in role:
-				                	role[splits[1]+"-"+splits[2]]+=" "+words[i]
-				               	else:
-				                	role[splits[1]+"-"+splits[2]]=words[i]  
-				elif(splits[0]=="B"):
-			       		temp=temp+" "+words[i]
-			       	elif(splits[0]=="I"):
-					temp=temp+" "+words[i]
-			      	elif(splits[0]=="E"):
-					temp=temp+" "+words[i]
-				       	if(len(splits)==2):
-				        	if(splits[1]=="V"):
-				                	role[splits[1]]=temp.strip()
-				               	else:
-				                   	if splits[1] in role:
-				                        	role[splits[1]]+=" "+temp
-				                             	role[splits[1]]=role[splits[1]].strip()
-				                        else:
-				                               	role[splits[1]]=temp.strip()
-				       	elif(len(splits)==3):
-				             	if splits[1]+"-"+splits[2] in role:
-				              		role[splits[1]+"-"+splits[2]]+=" "+temp
-				             		role[splits[1]+"-"+splits[2]]=role[splits[1]+"-"+splits[2]].strip()
-						else:
-				                	role[splits[1]+"-"+splits[2]]=temp.strip()
-				      	temp=""          
-			      	i+=1
-			if("V" in role):
-				roles+=[role]
-		annotations['words']=words
-		annotations['pos']=zip(words,pos)
-		annotations['ner']=zip(words,ner)
-		annotations['srl']=roles
-		annotations['verbs']=filter(lambda x: x!="-",verb)
-		annotations['chunk']=zip(words,chunk)
-		annotations['dep_parse']=""
-		annotations['syntax_tree']=""
-		for (w,s,p) in zip(words,syn,pos):
-			annotations['syntax_tree']+=s.replace("*","("+p+" "+w+")")
-		#annotations['syntax_tree']=annotations['syntax_tree'].replace("S1","S")
-		if(dep_parse):
-			annotations['dep_parse']=self.getDependency(annotations['syntax_tree'])
-		return annotations		
-	def getAnnotations(self,sentence,dep_parse=False):
-		annotations={}
-		senna_tags=self.getSennaTag(sentence)
-		senna_tags=map(lambda x: x.strip(),senna_tags.split("\n"))
-		no_verbs=len(senna_tags[0].split("\t"))-6
-		words=[]
-		pos=[]
-		chunk=[]
-		ner=[]
-		verb=[]
-		srls=[]
-		syn=[]
-		for senna_tag in senna_tags[0:-2]:
-			senna_tag=senna_tag.split("\t")
-			words+=[senna_tag[0].strip()]
-			pos+=[senna_tag[1].strip()]
-			chunk+=[senna_tag[2].strip()]
-			ner+=[senna_tag[3].strip()]
-			verb+=[senna_tag[4].strip()]
-			srl=[]
-			for i in range(5,5+no_verbs):
-				srl+=[senna_tag[i].strip()]
-			srls+=[tuple(srl)]
-			syn+=[senna_tag[-1]]
-		roles=[]
-		for j in range(no_verbs):
-			role={}
-			i=0
-			temp=""
-			curr_labels=map(lambda x: x[j],srls)
-			for curr_label in curr_labels:
-				splits=curr_label.split("-")
-				if(splits[0]=="S"):
-					if(len(splits)==2):
-				        	if(splits[1]=="V"):
-				                	role[splits[1]]=words[i]
-				                else:
-				                	if splits[1] in role:
-				                        	role[splits[1]]+=" "+words[i]
-				               		else:
-				                        	role[splits[1]]=words[i]
-				      	elif(len(splits)==3):
-				        	if splits[1]+"-"+splits[2] in role:
-				                	role[splits[1]+"-"+splits[2]]+=" "+words[i]
-				               	else:
-				                	role[splits[1]+"-"+splits[2]]=words[i]  
-				elif(splits[0]=="B"):
-			       		temp=temp+" "+words[i]
-			       	elif(splits[0]=="I"):
-					temp=temp+" "+words[i]
-			      	elif(splits[0]=="E"):
-					temp=temp+" "+words[i]
-				       	if(len(splits)==2):
-				        	if(splits[1]=="V"):
-				                	role[splits[1]]=temp.strip()
-				               	else:
-				                   	if splits[1] in role:
-				                        	role[splits[1]]+=" "+temp
-				                             	role[splits[1]]=role[splits[1]].strip()
-				                        else:
-				                               	role[splits[1]]=temp.strip()
-				       	elif(len(splits)==3):
-				             	if splits[1]+"-"+splits[2] in role:
-				              		role[splits[1]+"-"+splits[2]]+=" "+temp
-				             		role[splits[1]+"-"+splits[2]]=role[splits[1]+"-"+splits[2]].strip()
-						else:
-				                	role[splits[1]+"-"+splits[2]]=temp.strip()
-				      	temp=""          
-			      	i+=1
-			if("V" in role):
-				roles+=[role]
-		annotations['words']=words
-		annotations['pos']=zip(words,pos)
-		annotations['ner']=zip(words,ner)
-		annotations['srl']=roles
-		annotations['verbs']=filter(lambda x: x!="-",verb)
-		annotations['chunk']=zip(words,chunk)
-		annotations['dep_parse']=""
-		annotations['syntax_tree']=""
-		for (w,s,p) in zip(words,syn,pos):
-			annotations['syntax_tree']+=s.replace("*","("+p+" "+w+")")
-		#annotations['syntax_tree']=annotations['syntax_tree'].replace("S1","S")
-		if(dep_parse):
-			annotations['dep_parse']=self.getDependency(annotations['syntax_tree'])
-		return annotations
-def test():			
-	annotator=Annotator()
-	print annotator.getBatchAnnotations(["He killed the man with a knife and murdered him with a dagger.","He is a good boy."],dep_parse=True)
-	print annotator.getAnnotations("Republican candidate George Bush was great.",dep_parse=True)['dep_parse']
-	print annotator.getAnnotations("Republican candidate George Bush was great.",dep_parse=True)['chunk']
+    """
+    def getSennaTagBatch(self,sentences):
+        input_data=""
+        for sentence in sentences:
+            input_data+=sentence+"\n"
+        input_data=input_data[:-1]
+        package_directory = os.path.dirname(os.path.abspath(__file__))
+        os_name = system()
+        executable=""
+        if os_name == 'Linux':
+            bits = architecture()[0]
+            if bits == '64bit':
+                executable='senna-linux64'
+            elif bits == '32bit':
+                executable='senna-linux32'
+            else:
+                executable='senna'
+        if os_name == 'Windows':
+            executable='senna-win32.exe'
+        if os_name == 'Darwin':
+            executable='senna-osx'
+        senna_executable = os.path.join(package_directory,executable)
+        cwd=os.getcwd()
+        os.chdir(package_directory)
+        p = subprocess.Popen(senna_executable,stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        senna_stdout = p.communicate(input=input_data)[0]
+        os.chdir(cwd)
+        return senna_stdout.split("\n\n")[0:-1]
+
+    def getSennaTag(self,sentence):
+        input_data=sentence
+        package_directory = os.path.dirname(os.path.abspath(__file__))
+        os_name = system()
+        executable=""
+        if os_name == 'Linux':
+            bits = architecture()[0]
+            if bits == '64bit':
+                executable='senna-linux64'
+            elif bits == '32bit':
+                executable='senna-linux32'
+            else:
+                executable='senna'
+        if os_name == 'Windows':
+            executable='senna-win32.exe'
+        if os_name == 'Darwin':
+            executable='senna-osx'
+        senna_executable = os.path.join(package_directory,executable)
+        cwd=os.getcwd()
+        os.chdir(package_directory)
+        p = subprocess.Popen(senna_executable,stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        senna_stdout = p.communicate(input=input_data)[0]
+        os.chdir(cwd)
+        return senna_stdout
+    def getDependency(self,parse):
+        package_directory = os.path.dirname(os.path.abspath(__file__))
+        cwd=os.getcwd()
+        os.chdir(package_directory)
+        parsefile=open(cwd+"/in.parse","w")
+        parsefile.write(parse)
+        parsefile.close()
+        p=subprocess.Popen(['java','-cp','stanford-parser.jar', 'edu.stanford.nlp.trees.EnglishGrammaticalStructure', '-treeFile', cwd+'/in.parse','-collapsed'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        p.wait()
+        stanford_out=p.stdout.read()
+        os.chdir(cwd)
+        return stanford_out.strip()
+    def getBatchAnnotations(self,sentences,dep_parse=False):
+        annotations=[]
+        batch_senna_tags=self.getSennaTagBatch(sentences)
+        for senna_tags in batch_senna_tags:
+            annotations+=[self.getAnnotationsAfterTagging(senna_tags)]
+        if(dep_parse):
+            syntax_tree=""
+            for annotation in annotations:
+                syntax_tree+=annotation['syntax_tree']
+            dependencies=self.getDependency(syntax_tree).split("\n\n")
+            #print dependencies
+            if (len(annotations)==len(dependencies)):
+                for (d,a) in zip(dependencies,annotations):
+                    a["dep_parse"]=d
+        return annotations
+
+    def getAnnotationsAfterTagging(self,senna_tags,dep_parse=False):
+        annotations={}
+        senna_tags=map(lambda x: x.strip(),senna_tags.split("\n"))
+        no_verbs=len(senna_tags[0].split("\t"))-6
+        words=[]
+        pos=[]
+        chunk=[]
+        ner=[]
+        verb=[]
+        srls=[]
+        syn=[]
+        for senna_tag in senna_tags:
+            senna_tag=senna_tag.split("\t")
+            words+=[senna_tag[0].strip()]
+            pos+=[senna_tag[1].strip()]
+            chunk+=[senna_tag[2].strip()]
+            ner+=[senna_tag[3].strip()]
+            verb+=[senna_tag[4].strip()]
+            srl=[]
+            for i in range(5,5+no_verbs):
+                srl+=[senna_tag[i].strip()]
+            srls+=[tuple(srl)]
+            syn+=[senna_tag[-1]]
+        roles=[]
+        for j in range(no_verbs):
+            role={}
+            i=0
+            temp=""
+            curr_labels=map(lambda x: x[j],srls)
+            for curr_label in curr_labels:
+                splits=curr_label.split("-")
+                if(splits[0]=="S"):
+                    if(len(splits)==2):
+                        if(splits[1]=="V"):
+                            role[splits[1]]=words[i]
+                        else:
+                            if splits[1] in role:
+                                role[splits[1]]+=" "+words[i]
+                            else:
+                                role[splits[1]]=words[i]
+                    elif(len(splits)==3):
+                        if splits[1]+"-"+splits[2] in role:
+                            role[splits[1]+"-"+splits[2]]+=" "+words[i]
+                        else:
+                            role[splits[1]+"-"+splits[2]]=words[i]  
+                elif(splits[0]=="B"):
+                    temp=temp+" "+words[i]
+                elif(splits[0]=="I"):
+                    temp=temp+" "+words[i]
+                elif(splits[0]=="E"):
+                    temp=temp+" "+words[i]
+                    if(len(splits)==2):
+                        if(splits[1]=="V"):
+                            role[splits[1]]=temp.strip()
+                        else:
+                            if splits[1] in role:
+                                role[splits[1]]+=" "+temp
+                                role[splits[1]]=role[splits[1]].strip()
+                            else:
+                                role[splits[1]]=temp.strip()
+                    elif(len(splits)==3):
+                        if splits[1]+"-"+splits[2] in role:
+                            role[splits[1]+"-"+splits[2]]+=" "+temp
+                            role[splits[1]+"-"+splits[2]]=role[splits[1]+"-"+splits[2]].strip()
+                        else:
+                            role[splits[1]+"-"+splits[2]]=temp.strip()
+                    temp=""
+                i+=1
+            if("V" in role):
+                roles+=[role]
+        annotations['words']=words
+        annotations['pos']=zip(words,pos)
+        annotations['ner']=zip(words,ner)
+        annotations['srl']=roles
+        annotations['verbs']=filter(lambda x: x!="-",verb)
+        annotations['chunk']=zip(words,chunk)
+        annotations['dep_parse']=""
+        annotations['syntax_tree']=""
+        for (w,s,p) in zip(words,syn,pos):
+            annotations['syntax_tree']+=s.replace("*","("+p+" "+w+")")
+        #annotations['syntax_tree']=annotations['syntax_tree'].replace("S1","S")
+        if(dep_parse):
+            annotations['dep_parse']=self.getDependency(annotations['syntax_tree'])
+        return annotations
+    def getAnnotations(self,sentence,dep_parse=False):
+        annotations={}
+        senna_tags=self.getSennaTag(sentence)
+        senna_tags=map(lambda x: x.strip(),senna_tags.split("\n"))
+        no_verbs=len(senna_tags[0].split("\t"))-6
+        words=[]
+        pos=[]
+        chunk=[]
+        ner=[]
+        verb=[]
+        srls=[]
+        syn=[]
+        for senna_tag in senna_tags[0:-2]:
+            senna_tag=senna_tag.split("\t")
+            words+=[senna_tag[0].strip()]
+            pos+=[senna_tag[1].strip()]
+            chunk+=[senna_tag[2].strip()]
+            ner+=[senna_tag[3].strip()]
+            verb+=[senna_tag[4].strip()]
+            srl=[]
+            for i in range(5,5+no_verbs):
+                srl+=[senna_tag[i].strip()]
+            srls+=[tuple(srl)]
+            syn+=[senna_tag[-1]]
+        roles=[]
+        for j in range(no_verbs):
+            role={}
+            i=0
+            temp=""
+            curr_labels=map(lambda x: x[j],srls)
+            for curr_label in curr_labels:
+                splits=curr_label.split("-")
+                if(splits[0]=="S"):
+                    if(len(splits)==2):
+                        if(splits[1]=="V"):
+                            role[splits[1]]=words[i]
+                        else:
+                            if splits[1] in role:
+                                role[splits[1]]+=" "+words[i]
+                            else:
+                                role[splits[1]]=words[i]
+                    elif(len(splits)==3):
+                        if splits[1]+"-"+splits[2] in role:
+                            role[splits[1]+"-"+splits[2]]+=" "+words[i]
+                        else:
+                            role[splits[1]+"-"+splits[2]]=words[i]  
+                elif(splits[0]=="B"):
+                    temp=temp+" "+words[i]
+                elif(splits[0]=="I"):
+                    temp=temp+" "+words[i]
+                elif(splits[0]=="E"):
+                    temp=temp+" "+words[i]
+                    if(len(splits)==2):
+                        if(splits[1]=="V"):
+                            role[splits[1]]=temp.strip()
+                        else:
+                            if splits[1] in role:
+                                role[splits[1]]+=" "+temp
+                                role[splits[1]]=role[splits[1]].strip()
+                            else:
+                                role[splits[1]]=temp.strip()
+                    elif(len(splits)==3):
+                        if splits[1]+"-"+splits[2] in role:
+                            role[splits[1]+"-"+splits[2]]+=" "+temp
+                            role[splits[1]+"-"+splits[2]]=role[splits[1]+"-"+splits[2]].strip()
+                        else:
+                            role[splits[1]+"-"+splits[2]]=temp.strip()
+                    temp=""          
+                i+=1
+            if("V" in role):
+                roles+=[role]
+        annotations['words']=words
+        annotations['pos']=zip(words,pos)
+        annotations['ner']=zip(words,ner)
+        annotations['srl']=roles
+        annotations['verbs']=filter(lambda x: x!="-",verb)
+        annotations['chunk']=zip(words,chunk)
+        annotations['dep_parse']=""
+        annotations['syntax_tree']=""
+        for (w,s,p) in zip(words,syn,pos):
+            annotations['syntax_tree']+=s.replace("*","("+p+" "+w+")")
+        #annotations['syntax_tree']=annotations['syntax_tree'].replace("S1","S")
+        if(dep_parse):
+            annotations['dep_parse']=self.getDependency(annotations['syntax_tree'])
+        return annotations
+def test():
+    annotator=Annotator()
+    print(annotator.getBatchAnnotations(["He killed the man with a knife and murdered him with a dagger.","He is a good boy."],dep_parse=True))
+    print(annotator.getAnnotations("Republican candidate George Bush was great.",dep_parse=True)['dep_parse'])
+    print(annotator.getAnnotations("Republican candidate George Bush was great.",dep_parse=True)['chunk'])
 if __name__ == "__main__":
-	test()
+    test()


### PR DESCRIPTION
On Ubuntu LTS, I get the following error due to a mixture of tabs, spaces, and probably local settings:

```
python setup.py install
running install
running build
running build_py
copying practnlptools/tools.py -> build/lib/practnlptools
running install_lib
copying build/lib/practnlptools/tools.py -> /home/kinow/Development/python/anaconda3/lib/python3.5/site-packages/practnlptools
byte-compiling /home/kinow/Development/python/anaconda3/lib/python3.5/site-packages/practnlptools/tools.py to tools.cpython-35.pyc
Sorry: IndentationError: expected an indented block (tools.py, line 53)
```

Normally I don't have problems with tabs / spaces in other libraries, and I can see the indentation online via GitHub. So I believe it could be an issue with encoding, different settings in git, etc. This PR normalizes the code to use just spaces, which should make it a bit easier for devs in different platforms to edit / use it.